### PR TITLE
feat(scripts): integrate frontend web application build into snap pac…

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.0.3
+flask==1.1.2
 PyYAML==6.0
 requests==2.27.1
 urllib3==1.26.8

--- a/backend/service/service.py
+++ b/backend/service/service.py
@@ -23,7 +23,10 @@ from service import config
 from service.gateway import GatwayAPI
 
 
-app = Flask(__name__)
+app = Flask(
+    __name__,
+    static_folder="./static",
+)
 
 retry_strategy = Retry(
     total=3,
@@ -45,9 +48,11 @@ gateway = GatwayAPI(
     gateway_api_token
 )
 
+
 def render_error_response(msg, code):
     resp = {"error_msg": msg}
     return jsonify(resp), code
+
 
 @app.route('/1.0/sessions/', methods=['POST'])
 def api_1_0_sessions_post():
@@ -56,9 +61,18 @@ def api_1_0_sessions_post():
 
     return jsonify({}), 200
 
+
 @app.route('/1.0/games', methods=['GET'])
 def api_1_0_games_get():
     if not gateway_enabled:
         return render_error_response("no gateway connected", 503)
 
     return jsonify({}), 200
+
+@app.route('/')
+def root_file():
+    return app.send_static_file('index.html')
+
+@app.route('/<path:filename>')
+def static_file(filename):
+    return app.send_static_file(filename)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: cloud-gaming-demo
-base: core20
+base: core18
 summary: Cloud gaming demo for Anbox Cloud
 description: |
   The cloud gaming demo demonstrates how to build a cloud gaming service with Anbox Cloud (https://anbox-cloud.io/).
@@ -17,7 +17,8 @@ apps:
       - network-bind
     environment:
       PATH: $SNAP/bin/:$PATH
-      PYTHONPATH: $SNAP:$SNAP/lib/python3.8/site-packages
+      PYTHONPATH: $SNAP:$SNAP/lib/python3.6/site-packages
+    extensions: [flutter-master]
 
 parts:
   service:
@@ -45,3 +46,13 @@ parts:
       scripts/start-web.sh: bin/start-web.sh
     prime:
       - bin/start-web.sh
+
+  ui:
+    source: ui
+    plugin: flutter
+    after: [ service ]
+    flutter-target: lib/main.dart
+    override-build: |
+      flutter build web
+      mkdir -p $SNAPCRAFT_PART_INSTALL/service/static
+      cp -r build/web/* $SNAPCRAFT_PART_INSTALL/service/static


### PR DESCRIPTION
…kaging

This change integrates frontend web application build into snap package.
The flutter plugin is currently in beta and for now there are a few
limitations and caveats:
1. The flutter extension which provide many of the components needed
   to build Flutter applications doesn't work for `core20` base,
   for this reason, we have to use core18 base snap.
2. In order to build the flutter application, we added `[flutter-master]`
   extension to the webserver, however this extension is designed for
   the flutter desktop application and it uses `gnome-3-28` extension,
   this makes the snap a bit fat(16 MB) and connects a bunch of plugs
   like x11, opengl which are needless for a webserver based application.
3. As we have to use the base18 core snap, where python3.6 is installed
   natively to resolve the following conflict.
   ```
   The conflict is caused by:
    flask 2.0.3 depends on Werkzeug>=2.0
    talisker[flask,gevent,gunicorn] 0.19.0 depends on Werkzeug<1.2 and >=0.10.4

   ```
   we have to downgrade the flask to 1.1.2.

Test: build the snap package and install it locally and check if the
         UI served properly.