### PR TITLE
fix(scripts): fix the broken download link of bombsquad APK

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -32,7 +32,7 @@ DEMO_SNAP_COMMON_DIR="/var/snap/cloud-gaming-demo/common"
 APPLIANCE_SNAP_COMMON_DIR="/var/snap/anbox-cloud-appliance/common"
 
 GAMES="bombsquad mindustry"
-BOMBSQUAD_DOWNLOAD_URL="https://files.ballistica.net/bombsquad/builds/BombSquad_Android_Generic_1.6.10.apk"
+BOMBSQUAD_DOWNLOAD_URL="https://files.ballistica.net/bombsquad/builds/BombSquad_Android_Generic_1.7.1.apk"
 BOMBSQUAD_PKG_ARCH="universal"
 MINDUSTRY_DOWNLOAD_URL="https://f-droid.org/repo/io.anuke.mindustry_104.apk"
 MINDUSTRY_PKG_ARCH="universal"


### PR DESCRIPTION
The new version of bombsquad was released recently and the old version
(BombSquad_Android_Generic_1.6.10.apk) has been moved to '
`https://files.ballistica.net/bombsquad/builds/old/` folder.

Updating the download link of bombsquad APK pointing to the latest
version to avoid installation of cloud gaming demo being aborted
due to the broken download link.