### PR TITLE
fix(snap): bypass the proxy setup in launchpad

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -53,6 +53,8 @@ parts:
     after: [ service ]
     flutter-target: lib/main.dart
     override-build: |
+      # To bypass the proxy setup and build the snap on launchpad
+      export no_proxy=127.0.0.1
       flutter build web --base-href '/demo/'
       mkdir -p $SNAPCRAFT_PART_INSTALL/service/static
       cp -r build/web/* $SNAPCRAFT_PART_INSTALL/service/static


### PR DESCRIPTION
To build the snap on launchpad, where a builder proxy is setup, making
a request to 127.0.0.1 won't work. Hence we have to unset the proxy
for 127.0.0.1 to get the snap built on launchpad.

Test: build snap on launchpad